### PR TITLE
docs(iframe): document load_donation_iframe.js global-scope pollution + workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,48 @@ You can find more information by clicking on "Donation form"/"Spendenformular" i
 
 `https://www.betterplace.org/de/manage/projects/<your Project ID>/iframe_donation_form/new`
 
+### Known limitation: `load_donation_iframe.js` pollutes the global lexical scope
+
+The snippet that the portal generates includes a remote `<script src=".../load_donation_iframe.js" type="text/javascript">`. That bundle is a non-IIFE-wrapped script that declares roughly 150 single-letter `const`/`let`/`function` identifiers at top level — including a bare `$`, plus other very common single-letter names (`o`, `r`, `s`, `c`, `u`, `d`, `f`, `g`, `h`, `i`, `j`, `k`, `m`, `p`, `t`, `v`, `w`, `x`, `y`, `z`, …). In classic scripts (which is what the snippet uses), all top-level `let`/`const`/`class`/function declarations land in the shared **global lexical environment** of the realm.
+
+Consequence: if any other classic script on the page also declares `let $ = …` or `const $ = …` at top level (a browser extension, a second `iframe-resizer` instance loaded by another plugin, a build artifact from another vendor, …), parsing fails at load time with:
+
+```
+Uncaught SyntaxError: Identifier '$' has already been declared
+```
+
+Because this is a *parse-time* error, the loader script never runs — so its `loadDonationIframe()` call never fires and the embedding container stays at the spinner forever. The error is reported against the file that loses the race (often a Google Maps API request `js?…&callback=…`), making the actual root cause non-obvious.
+
+**Suggested upstream fix:** wrap the bundle output in an IIFE before it is served, e.g. `(function(){/* bundle */})();`. That keeps all declarations function-scoped and avoids polluting the global lexical environment entirely. Alternatively, serve the bundle as `<script type="module">`, which scopes top-level declarations to the module.
+
+**Workaround for integrators:** until the upstream loader is wrapped, you can skip the JS loader entirely and embed the iframe directly. The URL shape that `getIframeSource()` in the loader builds is:
+
+```
+https://www.betterplace.org/<lang>/donate/iframe/<receiver_type>s/<receiver_id>
+  ?background_color=<hex without #>
+  &color=<hex without #>
+  &donation_amount=<1–99>
+  &bottom_logo=<true|false>
+  &default_payment_method=<""|paypal|stripe|stripe_sepa_debit|apple_pay|google_pay>
+  &default_interval=<single|monthly|yearly>
+```
+
+Example (project `4667`, default 10 €, accent color `6c9c2e`, one-off):
+
+```html
+<iframe
+  src="https://www.betterplace.org/de/donate/iframe/projects/4667?background_color=ffffff&color=6c9c2e&donation_amount=10&bottom_logo=true&default_payment_method=&default_interval=single"
+  title="Donation form for project 4667"
+  loading="lazy"
+  referrerpolicy="strict-origin-when-cross-origin"
+  style="display:block;border:0;width:100%;max-width:600px;height:800px;background:transparent;">
+</iframe>
+```
+
+Trade-off: without the bundled `iframe-resizer`, the iframe cannot auto-grow with the form, so a sensible fixed `height` (≈ 780–850 px covers Step 1 + donor-details comfortably) is set instead.
+
+For WordPress sites, a community plugin that builds this URL via a shortcode and a Gutenberg block is available: **[s-a-s-k-i-a/betterplace-donation-embed](https://github.com/s-a-s-k-i-a/betterplace-donation-embed)** (GPL-2.0-or-later, minimal admin UI, no dependency on `load_donation_iframe.js`).
+
 ## Streaming Widgets and Donation Webhooks
 You can use our public API to show donation statistics and other details of your fundraising event. But we also have out-of-the box features for livestreams that you can use.
 


### PR DESCRIPTION
## Why

The portal-generated iframe-donation-form snippet pulls in `load_donation_iframe.js` as a classic `<script type="text/javascript">`. The bundle declares ~150 single-letter `const`/`let`/`function` identifiers at top level (line 130 of the loader, inside the bundled `iframe-resizer` 5.5.9 code):

```js
const o = "5.5.9", r = "iframeResizer", a = ":", s = "autoResize", l = "init",
      c = "iframeReady", u = "load", d = "message", f = "onload", p = "pageInfo",
      h = "parentInfo", m = "reset", g = "resize", y = "scroll", b = "\n",
      v = "child", w = "parent", z = "string",
      $ = "object",  // <-- bare $ declared at top level
      j = "function", k = "auto", T = "none", x = "both", /* ... */;
```

In classic scripts these declarations land in the shared **global lexical environment** of the realm. If any other classic script on the page also declares `let $` / `const $` / `class $` at top level (a browser extension, a second `iframe-resizer` instance from another vendor, a build artifact from another plugin, …), the second script fails to *parse* with:

```
Uncaught SyntaxError: Identifier '$' has already been declared
```

Because this is a parse-time error, the loader script never runs, `loadDonationIframe()` is never called, and the embedding `<div>` stays at the spinner forever. The error is reported against the file that loses the race (often a Google Maps `js?…&callback=…` request when the page also embeds a map), which makes the root cause non-obvious from the console alone.

We hit this in production on a WordPress site that has both:
- the betterplace iframe donation form snippet (provided by the portal), and
- the WP Store Locator plugin's Google Maps loader.

After ruling out duplicate Maps loads and inspecting `load_donation_iframe.js`, the bare top-level `$` declaration in the bundled iframe-resizer turned out to be the global-pollution source. A reproduction and full investigation lives at [s-a-s-k-i-a/betterplace-donation-embed#readme — "Why this exists"](https://github.com/s-a-s-k-i-a/betterplace-donation-embed#why-this-exists).

## What this PR changes

`README.md` only — adds a "Known limitation" subsection under the existing **Iframe donation form** section that:

1. Describes the global-lexical-pollution mechanism with the concrete line reference.
2. Suggests an upstream fix at the bundle level (wrap in an IIFE, or serve as `type="module"`) that would resolve it for *all* integrators in one step.
3. Gives integrators a copy-pasteable static-iframe workaround using the exact same URL shape that `getIframeSource()` in the loader builds — so the workaround stays 1:1 compatible with the official endpoint.
4. References a community WordPress plugin (shortcode + Gutenberg block, GPL-2.0-or-later) that implements the workaround.

No source code outside this repo is changed by this PR.

## Suggested upstream fix (out of scope for this PR)

The cleanest fix is at the bundle level — IIFE-wrap the served `load_donation_iframe.js`:

```js
(function () {
  /* existing bundle content */
})();
```

That moves all top-level `const`/`let`/`function` declarations into a function scope, leaving the global lexical environment untouched. It's a one-line change in the bundler config that fixes the issue for every integrator without breaking anything — the loader already encapsulates state via `window._bp_iframe`, so its public surface doesn't depend on top-level globals.

Alternatively, serving the loader as `type="module"` would also scope the declarations to the module, but that's a slightly bigger change because it shifts the inline-script pattern integrators use.

## Verification

The added section is descriptive only — no code paths touched. To verify the description:

```bash
curl -sL https://betterplace-assets.betterplace.org/assets/load_donation_iframe.js | sed -n '130p' | head -c 400
# const o = "5.5.9", r = "iframeResizer", a = ":", s = "autoResize", l = "init", c = "iframeReady", u = "load", d = "message", f = "onload", p = "pageInfo", h = "parentInfo", m = "reset", g = "resize", y = "scroll", b = "\n", v = "child", w = "parent", z = "string", $ = "object", j = "function", k = "auto", T = "none", x = "both",
```

Happy to revise wording / scope based on feedback. Thanks for considering!
